### PR TITLE
Allow nil in type declaration

### DIFF
--- a/src/state-definition.lisp
+++ b/src/state-definition.lisp
@@ -6,7 +6,7 @@
     :initarg :state :type non-nil-symbol :reader state
     :documentation "Name of the state.")
    (description
-    :initarg :description :initform nil :type string :reader description
+    :initarg :description :initform nil :type (or string null) :reader description
     :documentation "Description string. (Optional)")
    (terminal
     :initarg :terminal :initform nil :type boolean :reader terminal

--- a/src/transition-definition.lisp
+++ b/src/transition-definition.lisp
@@ -5,7 +5,7 @@
   ((from-state :initarg :from :reader from-state :type symbol)
    (to-state :initarg :to :reader to-state :type symbol)
    (description
-    :initarg :description :initform nil :type string :reader description
+    :initarg :description :initform nil :type (or string null) :reader description
     :documentation "Description string. (Optional)")
    (event :initarg :event :reader event :type symbol
           :documentation "Event name that triggers a transition to the


### PR DESCRIPTION
Hello,

I believe newer versions of sbcl require this.

Would you like to merge this?

Thanks, Roman.