### PR TITLE
Saner example build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 
 /tamagochi.exe
 
+/run-tamagochi

--- a/README.org
+++ b/README.org
@@ -40,6 +40,16 @@ Simple state machine DSL/library for CommonLisp.
   #+END_SRC
 
 
+  ..could use [[https://github.com/roswell/roswell][Roswell]] to execute and/or to build the example:
+
+  #+begin_src shell
+    $ ./run-tamagochi.ros
+
+    $ ros build run-tamagochi.ros
+    # ...will build: ./run-tamagochi
+  #+end_src
+
+
 * Basic Usages
   * I will omit the package name ~cl-state-machine:~ in every example
     codes below. (Consider every external symbol has been imported to

--- a/build-tamagochi-exec-clisp.sh
+++ b/build-tamagochi-exec-clisp.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
-CLISP=clisp
+#!/bin/bash
+CLISP=${CLISP:-clisp}
 
 ${CLISP} -x '(progn (load #p"src-examples/build-exe-tamagochi.lisp") (ext:quit))'

--- a/build-tamagochi-exec-ecl.sh
+++ b/build-tamagochi-exec-ecl.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
-ECL=ecl
+#!/bin/bash
+ECL=${ECL:-ecl}
 
 ${ECL} --load src-examples/build-exe-tamagochi.lisp --eval '(quit)'

--- a/build-tamagochi-exec-sbcl.sh
+++ b/build-tamagochi-exec-sbcl.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
-SBCL=run-sbcl.sh
+#!/bin/bash
+SBCL=${SBCL:-run-sbcl.sh}
 
 ${SBCL} --load src-examples/build-exe-tamagochi.lisp --quit

--- a/run-tamagochi.ros
+++ b/run-tamagochi.ros
@@ -1,0 +1,19 @@
+#!/bin/sh
+#|-*- mode:lisp -*-|#
+#|
+exec ros -Q -- $0 "$@"
+|#
+(progn ;;init forms
+  (ros:ensure-asdf)
+  #+quicklisp(ql:quickload '(cl-state-machine-examples) :silent t)
+  )
+
+(defpackage :ros.script.run-tamagochi.3954367612
+  (:use :cl))
+(in-package :ros.script.run-tamagochi.3954367612)
+
+(defun main (&rest argv)
+  (declare (ignorable argv))
+  (cl-state-machine-examples/tamagochi:run))
+
+;;; vim: set ft=lisp lisp:


### PR DESCRIPTION
1. overridable lisp compiler paths
2. roswell support